### PR TITLE
Fix files with spaces in their paths not opening

### DIFF
--- a/xopen
+++ b/xopen
@@ -5,11 +5,11 @@
 
 IFS=$'\n'
 
-if [[ -z "$*" ]]; then
+if [[ -z "$@" ]]; then
     echo "No file specified"
     exit 1
 fi
 
-for file in $*; do
+for file in "$@"; do
     nohup xdg-open "$file" &> /dev/null & disown
 done


### PR DESCRIPTION
### Steps to reproduce

1. `touch "test file.txt"`
2. `xopen "test file.txt"`

### Expected behavior

`test\ file.txt` should be opened with user's preferred editor.

### Actual behavior

Command apparently succeeds though nothing happens.

### Logs

If we modify the script to **not** send output to `/dev/null`:

```
for file in $*; do
    nohup xdg-open "$file"
done
```

We can check the logs inside `nohup.out`:

```
gio: file:///home/user/test: Error when getting information for file “/home/user/test”: No such file or directory
gio: file:///home/user/file.txt: Error when getting information for file “/home/user/file.txt”: No such file or directory
```
### Fix explanation

https://stackoverflow.com/a/256225
